### PR TITLE
進行中のゲームの棋譜をクライアントに漏らさないように修正。

### DIFF
--- a/public/goita.js
+++ b/public/goita.js
@@ -340,6 +340,8 @@ RoomInfo.prototype = {
       copy.player[i].tegoma = null; //hide secret info
       copy.player[i].openfield = null;
     }
+    // hide secret info
+    copy.kifu = [];
 
     return copy;
   },


### PR DESCRIPTION
伏せ駒の情報が client.roomInfo.kifu として取れてしまっていたのを、
クライアントには漏らさないように修正しました。

client.roomInfo.kifuText はラウンド終了時まで更新されないので、
ゲーム中に伏せ駒の情報が漏れることはありません。

よろしくお願いいたします。